### PR TITLE
Improve header spacing and map responsiveness

### DIFF
--- a/src/components/CommunityPage.tsx
+++ b/src/components/CommunityPage.tsx
@@ -122,9 +122,9 @@ export const CommunityPage = () => {
       });
 
   return (
-    <div className="min-h-screen bg-background pb-20">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <div className="bg-gradient-to-r from-civic-amber to-civic-amber/80 text-black px-4 py-8 safe-area-padding-top">
+      <div className="bg-gradient-to-r from-civic-amber to-civic-amber/80 text-black px-4 pt-12 pb-8 safe-area-padding-top">
         <div className="max-w-md mx-auto">
           <h1 className="text-2xl font-bold mb-2">Community</h1>
           <p className="text-black/80">Stay connected with your neighborhood</p>

--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -77,9 +77,9 @@ export const Homepage = ({ onReportIssue, onNavigate }: HomepageProps) => {
   };
 
   return (
-    <div className="min-h-screen bg-background pb-20">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <div className="bg-gradient-to-r from-primary to-primary-glow text-primary-foreground px-4 py-8 safe-area-padding-top">
+      <div className="bg-gradient-to-r from-primary to-primary-glow text-primary-foreground px-4 pt-12 pb-8 safe-area-padding-top">
         <div className="max-w-md mx-auto">
           <div className="flex items-center gap-3 mb-3">
             <div className="w-10 h-10 bg-white/20 rounded-lg flex items-center justify-center">

--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -125,9 +125,9 @@ export const MapView = () => {
   }
 
   return (
-    <div className="w-full min-h-[calc(100vh-7rem)] md:min-h-[calc(100vh-3rem)] flex flex-col md:flex-row">
+    <div className="w-full h-[calc(100vh-7rem)] md:h-[calc(100vh-2rem)] flex flex-col md:flex-row overflow-hidden">
       {/* Map */}
-      <div className="flex-1 relative min-h-[60vh] md:min-h-0">
+      <div className="flex-1 relative min-h-[60vh] md:min-h-0 md:h-full">
         <InteractiveMap
           incidents={incidents}
           userLocation={latitude && longitude ? { latitude, longitude } : null}
@@ -174,7 +174,7 @@ export const MapView = () => {
       </div>
 
       {/* Mobile-responsive Incidents Sidebar */}
-      <div className="md:w-80 bg-card border-t md:border-t-0 md:border-l border-border overflow-y-auto max-h-[40vh] md:max-h-none">
+      <div className="md:w-80 bg-card border-t md:border-t-0 md:border-l border-border overflow-y-auto max-h-[40vh] md:max-h-none md:h-full">
         <div className="p-4">
           <div className="flex items-center justify-between mb-4">
             <div>

--- a/src/components/ProfilePage.tsx
+++ b/src/components/ProfilePage.tsx
@@ -67,9 +67,9 @@ export const ProfilePage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-background pb-20">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <div className="bg-gradient-to-r from-primary to-primary-glow text-primary-foreground px-4 py-8 safe-area-padding-top">
+      <div className="bg-gradient-to-r from-primary to-primary-glow text-primary-foreground px-4 pt-12 pb-8 safe-area-padding-top">
         <div className="max-w-md mx-auto text-center">
           <div className="w-20 h-20 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
             <User className="w-10 h-10" />

--- a/src/components/ServicesPage.tsx
+++ b/src/components/ServicesPage.tsx
@@ -58,9 +58,9 @@ export const ServicesPage = () => {
   ];
 
   return (
-    <div className="min-h-screen bg-background pb-20">
+    <div className="min-h-screen bg-background">
       {/* Header */}
-      <div className="bg-gradient-to-r from-civic-emerald to-civic-emerald/80 text-white px-4 py-8 safe-area-padding-top">
+      <div className="bg-gradient-to-r from-civic-emerald to-civic-emerald/80 text-white px-4 pt-12 pb-8 safe-area-padding-top">
         <div className="max-w-md mx-auto">
           <h1 className="text-2xl font-bold mb-2">Local Services</h1>
           <p className="text-white/90">Access municipal services and emergency contacts</p>


### PR DESCRIPTION
## Summary
- increase top padding on page headers and remove extra bottom padding to prevent scrolling issues
- ensure MapView fills the screen and sidebar height is responsive

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68c69c9843c0832984a58f9838731237